### PR TITLE
fix: test randomly failing

### DIFF
--- a/test/unit/BPool.t.sol
+++ b/test/unit/BPool.t.sol
@@ -2854,7 +2854,7 @@ contract BPool_Unit_ExitswapExternAmountOut is BasePoolTest {
     _fuzz.totalWeight = bound(_fuzz.totalWeight, MIN_WEIGHT * TOKENS_AMOUNT, MAX_TOTAL_WEIGHT);
 
     // min
-    _fuzz.totalSupply = bound(_fuzz.totalSupply, INIT_POOL_SUPPLY, type(uint256).max);
+    _fuzz.totalSupply = bound(_fuzz.totalSupply, INIT_POOL_SUPPLY, type(uint256).max / BONE);
 
     // MAX_OUT_RATIO
     vm.assume(_fuzz.tokenOutBalance < type(uint256).max / MAX_OUT_RATIO);


### PR DESCRIPTION
Closes BAL-74

The problem was when setting `_fuzz.tokenAmountOut == 0` [`poolRatio`](https://github.com/defi-wonderland/balancer-v1-amm/blob/6c85298d9bd303dc7cd703d69c7c314c4a22d031/src/contracts/BMath.sol#L243) end up being `1` (or `1e18`). Fixed by capping the `totalSupply` to `uint.max / 1e18` to give some space for `bmul`.