### PR TITLE
fix: comment in bnum formula

### DIFF
--- a/src/contracts/BMath.sol
+++ b/src/contracts/BMath.sol
@@ -212,7 +212,7 @@ contract BMath is BBronze, BConst, BNum {
    *    calcPoolInGivenSingleOut
    *    pAi = poolAmountIn               // /               tAo             \\     / wO \     \
    *    bO = tokenBalanceOut            // | bO - -------------------------- |\   | ---- |     \
-   *    tAo = tokenAmountOut      pS - ||   \     1 - ((1 - (tO / tW)) * sF)/  | ^ \ tW /  * pS |
+   *    tAo = tokenAmountOut      pS - ||   \     1 - ((1 - (wO / tW)) * sF)/  | ^ \ tW /  * pS |
    *    ps = poolSupply                 \\ -----------------------------------/                /
    *    wO = tokenWeightOut  pAi =       \\               bO                 /                /
    *    tW = totalWeight           -------------------------------------------------------------

--- a/src/contracts/BMath.sol
+++ b/src/contracts/BMath.sol
@@ -136,9 +136,9 @@ contract BMath is BBronze, BConst, BNum {
    *    pS = poolSupply                 || ---------  | ^ | --------- || * bI - bI
    *    pAo = poolAmountOut              \\    pS    /     \(wI / tW)//
    *    bI = balanceIn          tAi =  --------------------------------------------
-   *    wI = weightIn                              /      wI  \
-   *    tW = totalWeight                          |  1 - ----  |  * sF
-   *    sF = swapFee                               \      tW  /
+   *    wI = weightIn                              /      wI        \
+   *    tW = totalWeight                          |  1 - ----  * sF  |
+   *    sF = swapFee                               \      tW        /
    *
    */
   function calcSingleInGivenPoolOut(


### PR DESCRIPTION
Reference: https://github.com/balancer/balancer-core/pull/250/commits/43582453ecd9d0fa525f0335f5d957b415b20457

Bug: in `calcSingleInGivenPoolOut` the swapFee was such that 0 would cause an overflow