### PR TITLE
chore: bump solidity version to 0.8.25

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -9,7 +9,7 @@ multiline_func_header = 'params_first'
 sort_imports = true
 
 [profile.default]
-solc_version = '0.8.23'
+solc_version = '0.8.25'
 libs = ["node_modules", "lib"]
 optimizer_runs = 50             # TODO: increase for production and add via-ir
 ffi = true

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity 0.8.25;
 
 import {BFactory} from 'contracts/BFactory.sol';
 import {Params} from 'script/Params.s.sol';

--- a/script/Params.s.sol
+++ b/script/Params.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity 0.8.25;
 
 contract Params {
   struct DeploymentParams {

--- a/src/contracts/BConst.sol
+++ b/src/contracts/BConst.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.23;
+pragma solidity 0.8.25;
 
 contract BConst {
   uint256 public constant BONE = 10 ** 18;

--- a/src/contracts/BFactory.sol
+++ b/src/contracts/BFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.23;
+pragma solidity 0.8.25;
 
 // Builds new BPools, logging their addresses and providing `isBPool(address) -> (bool)`
 import {BPool} from './BPool.sol';

--- a/src/contracts/BMath.sol
+++ b/src/contracts/BMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.23;
+pragma solidity 0.8.25;
 
 import {BConst} from './BConst.sol';
 import {BNum} from './BNum.sol';

--- a/src/contracts/BNum.sol
+++ b/src/contracts/BNum.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.23;
+pragma solidity 0.8.25;
 
 import {BConst} from './BConst.sol';
 

--- a/src/contracts/BPool.sol
+++ b/src/contracts/BPool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.23;
+pragma solidity 0.8.25;
 
 import {BMath} from './BMath.sol';
 

--- a/src/contracts/BToken.sol
+++ b/src/contracts/BToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.23;
+pragma solidity 0.8.25;
 
 import {BNum} from './BNum.sol';
 

--- a/src/interfaces/IBFactory.sol
+++ b/src/interfaces/IBFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.23;
+pragma solidity 0.8.25;
 
 import {IBPool} from 'interfaces/IBPool.sol';
 

--- a/src/interfaces/IBPool.sol
+++ b/src/interfaces/IBPool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.23;
+pragma solidity 0.8.25;
 
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 

--- a/test/integration/DeploymentGas.t.sol
+++ b/test/integration/DeploymentGas.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity 0.8.25;
 
 import {BFactory} from 'contracts/BFactory.sol';
 

--- a/test/integration/PoolSwap.t.sol
+++ b/test/integration/PoolSwap.t.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.23;
+pragma solidity 0.8.25;
 
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import {Test} from 'forge-std/Test.sol';

--- a/test/unit/BFactory.t.sol
+++ b/test/unit/BFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity 0.8.25;
 
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 

--- a/test/unit/BPool.t.sol
+++ b/test/unit/BPool.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity 0.8.25;
 
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 

--- a/test/unit/BToken.t.sol
+++ b/test/unit/BToken.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.25;
 
 import {IERC20Errors} from '@openzeppelin/contracts/interfaces/draft-IERC6093.sol';
 import {Test} from 'forge-std/Test.sol';

--- a/test/utils/Pow.sol
+++ b/test/utils/Pow.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity 0.8.25;
 
 import {BNum} from 'contracts/BNum.sol';
 

--- a/test/utils/Utils.sol
+++ b/test/utils/Utils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity 0.8.25;
 
 import {Test} from 'forge-std/Test.sol';
 import {LibString} from 'solmate/utils/LibString.sol';


### PR DESCRIPTION
closes BAL-69 
(nice)

feedback wanted on:
- [ ] is it okay if I set the compiler version to 0.8.25 instead of 0.8.26? `foundry-smock` relies on `solc-typed-ast` which hasn't yet pushed a release supporting the latest version
- [ ] where will this be deployed? solidity 0.8.25 switched the default evm version to cancun, and that might break deployments on chains other than mainnet
- [ ] since solidity 0.8.24 we have support for transient storage. A possible gas opt would be to use it to have cheaper reentrancy locks. Should that be part of this PR? logged somewhere so we can tackle it later if we have the time?
