### PR TITLE
feat: adding BCoWFactory

### DIFF
--- a/src/contracts/BCoWFactory.sol
+++ b/src/contracts/BCoWFactory.sol
@@ -9,22 +9,22 @@ import {IBPool} from 'interfaces/IBPool.sol';
 
 /**
  * @title BCoWFactory
- * @notice Creates new BPools, logging their addresses and acting as a registry of pools.
+ * @notice Creates new BCoWPools, logging their addresses and acting as a registry of pools.
  */
 contract BCoWFactory is BFactory {
-  address public solutionSettler;
+  address public immutable SOLUTION_SETTLER;
 
   constructor(address _solutionSettler) BFactory() {
-    solutionSettler = _solutionSettler;
+    SOLUTION_SETTLER = _solutionSettler;
   }
 
   /**
    * @inheritdoc IBFactory
-   * @dev deploys a BCoWPool instead of a regular BPool, maintains the interface
+   * @dev Deploys a BCoWPool instead of a regular BPool, maintains the interface
    * to minimize required changes to existing tooling
    */
   function newBPool() external override returns (IBPool _pool) {
-    IBPool bpool = new BCoWPool(solutionSettler);
+    IBPool bpool = new BCoWPool(SOLUTION_SETTLER);
     _isBPool[address(bpool)] = true;
     emit LOG_NEW_POOL(msg.sender, address(bpool));
     bpool.setController(msg.sender);

--- a/src/contracts/BCoWFactory.sol
+++ b/src/contracts/BCoWFactory.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.25;
+
+import {BCoWPool} from './BCoWPool.sol';
+
+import {BFactory} from './BFactory.sol';
+import {IBFactory} from 'interfaces/IBFactory.sol';
+import {IBPool} from 'interfaces/IBPool.sol';
+
+/**
+ * @title BCoWFactory
+ * @notice Creates new BPools, logging their addresses and acting as a registry of pools.
+ */
+contract BCoWFactory is BFactory {
+  address public solutionSettler;
+
+  constructor(address _solutionSettler) BFactory() {
+    solutionSettler = _solutionSettler;
+  }
+
+  /**
+   * @inheritdoc IBFactory
+   * @dev deploys a BCoWPool instead of a regular BPool, maintains the interface
+   * to minimize required changes to existing tooling
+   */
+  function newBPool() external override returns (IBPool _pool) {
+    IBPool bpool = new BCoWPool(solutionSettler);
+    _isBPool[address(bpool)] = true;
+    emit LOG_NEW_POOL(msg.sender, address(bpool));
+    bpool.setController(msg.sender);
+    return bpool;
+  }
+}

--- a/src/contracts/BFactory.sol
+++ b/src/contracts/BFactory.sol
@@ -20,7 +20,7 @@ contract BFactory is IBFactory {
   }
 
   /// @inheritdoc IBFactory
-  function newBPool() external returns (IBPool _pool) {
+  function newBPool() external virtual returns (IBPool _pool) {
     IBPool bpool = new BPool();
     _isBPool[address(bpool)] = true;
     emit LOG_NEW_POOL(msg.sender, address(bpool));

--- a/test/smock/MockBCoWFactory.sol
+++ b/test/smock/MockBCoWFactory.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+import {BCoWFactory, BCoWPool, BFactory, IBFactory, IBPool} from '../../src/contracts/BCoWFactory.sol';
+import {Test} from 'forge-std/Test.sol';
+
+contract MockBCoWFactory is BCoWFactory, Test {
+  function set_solutionSettler(address _solutionSettler) public {
+    solutionSettler = _solutionSettler;
+  }
+
+  function mock_call_solutionSettler(address _value) public {
+    vm.mockCall(address(this), abi.encodeWithSignature('solutionSettler()'), abi.encode(_value));
+  }
+
+  constructor(address _solutionSettler) BCoWFactory(_solutionSettler) {}
+
+  function mock_call_newBPool(IBPool _pool) public {
+    vm.mockCall(address(this), abi.encodeWithSignature('newBPool()'), abi.encode(_pool));
+  }
+}

--- a/test/smock/MockBCoWFactory.sol
+++ b/test/smock/MockBCoWFactory.sol
@@ -5,14 +5,6 @@ import {BCoWFactory, BCoWPool, BFactory, IBFactory, IBPool} from '../../src/cont
 import {Test} from 'forge-std/Test.sol';
 
 contract MockBCoWFactory is BCoWFactory, Test {
-  function set_solutionSettler(address _solutionSettler) public {
-    solutionSettler = _solutionSettler;
-  }
-
-  function mock_call_solutionSettler(address _value) public {
-    vm.mockCall(address(this), abi.encodeWithSignature('solutionSettler()'), abi.encode(_value));
-  }
-
   constructor(address _solutionSettler) BCoWFactory(_solutionSettler) {}
 
   function mock_call_newBPool(IBPool _pool) public {

--- a/test/unit/BCoWFactory.t.sol
+++ b/test/unit/BCoWFactory.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+
+import {Base, BaseBFactory_Unit_Constructor, BaseBFactory_Unit_NewBPool} from './BFactory.t.sol';
+
+import {IBCoWPool} from 'interfaces/IBCoWPool.sol';
+import {IBFactory} from 'interfaces/IBFactory.sol';
+import {ISettlement} from 'interfaces/ISettlement.sol';
+import {MockBCoWFactory} from 'test/smock/MockBCoWFactory.sol';
+
+abstract contract BCoWFactoryTest is Base {
+  address public solutionSettler = makeAddr('solutionSettler');
+
+  function _configureBFactory() internal override returns (IBFactory) {
+    vm.mockCall(solutionSettler, abi.encodePacked(ISettlement.domainSeparator.selector), abi.encode(bytes32(0)));
+    vm.mockCall(
+      solutionSettler, abi.encodePacked(ISettlement.vaultRelayer.selector), abi.encode(makeAddr('vault relayer'))
+    );
+    vm.prank(owner);
+    return new MockBCoWFactory(solutionSettler);
+  }
+}
+
+contract BCoWFactory_Unit_Constructor is BaseBFactory_Unit_Constructor, BCoWFactoryTest {
+  function test_Set_SolutionSettler(address _settler) public {
+    MockBCoWFactory factory = new MockBCoWFactory(_settler);
+    assertEq(factory.solutionSettler(), _settler);
+  }
+}
+
+contract BCoWFactory_Unit_NewBPool is BaseBFactory_Unit_NewBPool, BCoWFactoryTest {
+  function test_Set_SolutionSettler(address _settler) public {
+    MockBCoWFactory(address(bFactory)).set_solutionSettler(_settler);
+    vm.mockCall(_settler, abi.encodePacked(ISettlement.domainSeparator.selector), abi.encode(bytes32(0)));
+    vm.mockCall(_settler, abi.encodePacked(ISettlement.vaultRelayer.selector), abi.encode(makeAddr('vault relayer')));
+    IBCoWPool bCoWPool = IBCoWPool(address(bFactory.newBPool()));
+    assertEq(address(bCoWPool.SOLUTION_SETTLER()), _settler);
+  }
+}

--- a/test/unit/BCoWFactory.t.sol
+++ b/test/unit/BCoWFactory.t.sol
@@ -26,13 +26,14 @@ abstract contract BCoWFactoryTest is Base {
 contract BCoWFactory_Unit_Constructor is BaseBFactory_Unit_Constructor, BCoWFactoryTest {
   function test_Set_SolutionSettler(address _settler) public {
     MockBCoWFactory factory = new MockBCoWFactory(_settler);
-    assertEq(factory.solutionSettler(), _settler);
+    assertEq(factory.SOLUTION_SETTLER(), _settler);
   }
 }
 
 contract BCoWFactory_Unit_NewBPool is BaseBFactory_Unit_NewBPool, BCoWFactoryTest {
   function test_Set_SolutionSettler(address _settler) public {
-    MockBCoWFactory(address(bFactory)).set_solutionSettler(_settler);
+    vm.prank(owner);
+    bFactory = new MockBCoWFactory(_settler);
     vm.mockCall(_settler, abi.encodePacked(ISettlement.domainSeparator.selector), abi.encode(bytes32(0)));
     vm.mockCall(_settler, abi.encodePacked(ISettlement.vaultRelayer.selector), abi.encode(makeAddr('vault relayer')));
     IBCoWPool bCoWPool = IBCoWPool(address(bFactory.newBPool()));

--- a/test/unit/BFactory.t.sol
+++ b/test/unit/BFactory.t.sol
@@ -10,16 +10,24 @@ import {IBFactory} from 'interfaces/IBFactory.sol';
 import {IBPool} from 'interfaces/IBPool.sol';
 
 abstract contract Base is Test {
-  BFactory public bFactory;
+  IBFactory public bFactory;
   address public owner = makeAddr('owner');
 
-  function setUp() public {
-    vm.prank(owner);
-    bFactory = new BFactory();
+  function _configureBFactory() internal virtual returns (IBFactory);
+
+  function setUp() public virtual {
+    bFactory = _configureBFactory();
   }
 }
 
-contract BFactory_Unit_Constructor is Base {
+abstract contract BFactoryTest is Base {
+  function _configureBFactory() internal override returns (IBFactory) {
+    vm.prank(owner);
+    return new BFactory();
+  }
+}
+
+abstract contract BaseBFactory_Unit_Constructor is Base {
   /**
    * @notice Test that the owner is set correctly
    */
@@ -28,7 +36,10 @@ contract BFactory_Unit_Constructor is Base {
   }
 }
 
-contract BFactory_Unit_IsBPool is Base {
+// solhint-disable-next-line no-empty-blocks
+contract BFactory_Unit_Constructor is BFactoryTest, BaseBFactory_Unit_Constructor {}
+
+contract BFactory_Unit_IsBPool is BFactoryTest {
   /**
    * @notice Test that a valid pool is present on the mapping
    */
@@ -47,7 +58,7 @@ contract BFactory_Unit_IsBPool is Base {
   }
 }
 
-contract BFactory_Unit_NewBPool is Base {
+abstract contract BaseBFactory_Unit_NewBPool is Base {
   /**
    * @notice Test that the pool is set on the mapping
    */
@@ -90,7 +101,10 @@ contract BFactory_Unit_NewBPool is Base {
   }
 }
 
-contract BFactory_Unit_GetBLabs is Base {
+// solhint-disable-next-line no-empty-blocks
+contract BFactory_Unit_NewBPool is BFactoryTest, BaseBFactory_Unit_NewBPool {}
+
+contract BFactory_Unit_GetBLabs is BFactoryTest {
   /**
    * @notice Test that the correct owner is returned
    */
@@ -101,7 +115,7 @@ contract BFactory_Unit_GetBLabs is Base {
   }
 }
 
-contract BFactory_Unit_SetBLabs is Base {
+contract BFactory_Unit_SetBLabs is BFactoryTest {
   /**
    * @notice Test that only the owner can set the BLabs
    */
@@ -132,7 +146,7 @@ contract BFactory_Unit_SetBLabs is Base {
   }
 }
 
-contract BFactory_Unit_Collect is Base {
+contract BFactory_Unit_Collect is BFactoryTest {
   /**
    * @notice Test that only the owner can collect
    */


### PR DESCRIPTION
I tried to give #76 a second try and feel comfortable with how it turned out, being able to test the new functionality while retainig the old tests. 

questions (in scope for this PR)

- [ ] is it okay to keep the same interface, since the return value of `newBPool` is now different( but does comply to `IBPool` )? I felt it was desirable to keep a uniform interface for existing tooling, but I don't have any actual context for that.

questions (out of scope for this PR)

- [ ] are we sure it's okay to hard-code the vault relayer address into an immutable variable? would it be possible for `ISettlement` to return a different one at some other point in time?

outstanding issues (I don't want to block anyone else so I propose they have their own PRs)

- [ ] extract `solutionSettler` method into an `IBCoWFactory` interface (well, that's contingent on feedback on this PR)
- [ ] `setSolutionSettler` method, permissioned to `bLabs`

other comments: 

- I tried to have a factory able to deploy both kinds of pools, but its codesize grew to 36912 bytes

