### PR TITLE
fix: assuming not forge address in test

### DIFF
--- a/test/unit/BCoWFactory.t.sol
+++ b/test/unit/BCoWFactory.t.sol
@@ -32,7 +32,7 @@ contract BCoWFactory_Unit_Constructor is BaseBFactory_Unit_Constructor, BCoWFact
 
 contract BCoWFactory_Unit_NewBPool is BaseBFactory_Unit_NewBPool, BCoWFactoryTest {
   function test_Set_SolutionSettler(address _settler) public {
-    vm.prank(owner);
+    assumeNotForgeAddress(_settler);
     bFactory = new MockBCoWFactory(_settler);
     vm.mockCall(_settler, abi.encodePacked(ISettlement.domainSeparator.selector), abi.encode(bytes32(0)));
     vm.mockCall(_settler, abi.encodePacked(ISettlement.vaultRelayer.selector), abi.encode(makeAddr('vault relayer')));


### PR DESCRIPTION
Re adding changes introduced in #97, erased in merge conflicts with #95 

https://github.com/defi-wonderland/balancer-v1-amm/pull/96/files#diff-3b15c3a0113e0fdd7eecc43b3fe00a6f7d8f95be5e7ee78fa1dd839292586af5