### PR TITLE
fix: informational findings in IR

### DIFF
--- a/src/contracts/BCoWPool.sol
+++ b/src/contracts/BCoWPool.sol
@@ -114,7 +114,7 @@ contract BCoWPool is IERC1271, IBCoWPool, BPool, BCoWConst {
 
     uint256 buyTokenBalance = order.buyToken.balanceOf(address(this));
     if (order.buyAmount > bmul(buyTokenBalance, MAX_IN_RATIO)) {
-      revert BPool_TokenAmountInAboveMaxIn();
+      revert BPool_TokenAmountInAboveMaxRatio();
     }
 
     uint256 tokenAmountOut = calcOutGivenIn({

--- a/src/contracts/BPool.sol
+++ b/src/contracts/BPool.sol
@@ -249,7 +249,7 @@ contract BPool is BToken, BMath, IBPool {
     uint256 tokenOutBalance = IERC20(tokenOut).balanceOf(address(this));
 
     if (tokenAmountIn > bmul(tokenInBalance, MAX_IN_RATIO)) {
-      revert BPool_TokenAmountInAboveMaxIn();
+      revert BPool_TokenAmountInAboveMaxRatio();
     }
 
     uint256 spotPriceBefore =
@@ -364,7 +364,7 @@ contract BPool is BToken, BMath, IBPool {
     Record storage inRecord = _records[tokenIn];
     uint256 tokenInBalance = IERC20(tokenIn).balanceOf(address(this));
     if (tokenAmountIn > bmul(tokenInBalance, MAX_IN_RATIO)) {
-      revert BPool_TokenAmountInAboveMaxIn();
+      revert BPool_TokenAmountInAboveMaxRatio();
     }
 
     poolAmountOut =
@@ -408,7 +408,7 @@ contract BPool is BToken, BMath, IBPool {
       revert BPool_TokenAmountInAboveMaxAmountIn();
     }
     if (tokenAmountIn > bmul(tokenInBalance, MAX_IN_RATIO)) {
-      revert BPool_TokenAmountInAboveMaxIn();
+      revert BPool_TokenAmountInAboveMaxRatio();
     }
 
     emit LOG_JOIN(msg.sender, tokenIn, tokenAmountIn);

--- a/src/interfaces/IBPool.sol
+++ b/src/interfaces/IBPool.sol
@@ -265,7 +265,7 @@ interface IBPool is IERC20 {
   ) external returns (uint256 tokenAmountOut, uint256 spotPriceAfter);
 
   /**
-   * @notice Swaps as many tokens in as possible for an exact amount of tokens out
+   * @notice Swaps as many tokens in as needed for an exact amount of tokens out
    * @param tokenIn The address of the token to swap in
    * @param maxAmountIn The maximum amount of token to swap in
    * @param tokenOut The address of the token to swap out

--- a/src/interfaces/IBPool.sol
+++ b/src/interfaces/IBPool.sol
@@ -152,9 +152,9 @@ interface IBPool is IERC20 {
   error BPool_PoolNotFinalized();
 
   /**
-   * @notice Thrown when the token amount in surpasses the maximum in allowed by the pool
+   * @notice Thrown when the token amount in surpasses the maximum in ratio allowed by the pool
    */
-  error BPool_TokenAmountInAboveMaxIn();
+  error BPool_TokenAmountInAboveMaxRatio();
 
   /**
    * @notice Thrown when the spot price before the swap is above the max allowed by the caller

--- a/test/unit/BCoWPool.t.sol
+++ b/test/unit/BCoWPool.t.sol
@@ -253,7 +253,7 @@ contract BCoWPool_Unit_Verify is BaseCoWPoolTest, SwapExactAmountInUtils {
     GPv2Order.Data memory order = correctOrder;
     order.buyAmount = _tokenAmountIn;
 
-    vm.expectRevert(IBPool.BPool_TokenAmountInAboveMaxIn.selector);
+    vm.expectRevert(IBPool.BPool_TokenAmountInAboveMaxRatio.selector);
     bCoWPool.verify(order);
   }
 

--- a/test/unit/BPool.t.sol
+++ b/test/unit/BPool.t.sol
@@ -1533,7 +1533,7 @@ contract BPool_Unit_SwapExactAmountIn is SwapExactAmountInUtils {
   function test_Revert_TokenAmountInAboveMaxIn(SwapExactAmountIn_FuzzScenario memory _fuzz) public happyPath(_fuzz) {
     uint256 _tokenAmountIn = bmul(_fuzz.tokenInBalance, MAX_IN_RATIO) + 1;
 
-    vm.expectRevert(IBPool.BPool_TokenAmountInAboveMaxIn.selector);
+    vm.expectRevert(IBPool.BPool_TokenAmountInAboveMaxRatio.selector);
     bPool.swapExactAmountIn(tokenIn, _tokenAmountIn, tokenOut, 0, type(uint256).max);
   }
 
@@ -2167,7 +2167,7 @@ contract BPool_Unit_JoinswapExternAmountIn is BasePoolTest {
   {
     uint256 _tokenAmountIn = bmul(_fuzz.tokenInBalance, MAX_IN_RATIO);
 
-    vm.expectRevert(IBPool.BPool_TokenAmountInAboveMaxIn.selector);
+    vm.expectRevert(IBPool.BPool_TokenAmountInAboveMaxRatio.selector);
     bPool.joinswapExternAmountIn(tokenIn, _tokenAmountIn + 1, 0);
   }
 
@@ -2399,7 +2399,7 @@ contract BPool_Unit_JoinswapPoolAmountOut is BasePoolTest {
 
     _setValues(_fuzz);
 
-    vm.expectRevert(IBPool.BPool_TokenAmountInAboveMaxIn.selector);
+    vm.expectRevert(IBPool.BPool_TokenAmountInAboveMaxRatio.selector);
     bPool.joinswapPoolAmountOut(tokenIn, _fuzz.poolAmountOut, type(uint256).max);
   }
 


### PR DESCRIPTION
Closes BAL-130, BAL-129

- renames `TokenAmountInAboveMaxIn` as it was too similar to `BPool_TokenAmountInAboveMaxAmountIn`
- fixes `swapExactAmountOut` natspec