### PR TITLE
ci: run all foundry tests regardless of their name

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "prepare": "husky install",
     "smock": "smock-foundry --contracts src/contracts",
     "test": "forge test -vvv",
-    "test:integration": "forge test --match-contract Integration -vvv --isolate",
+    "test:integration": "forge test --match-path 'test/integration/**' -vvv --isolate",
     "test:local": "FOUNDRY_FUZZ_RUNS=100 forge test -vvv",
-    "test:unit": "forge test --match-contract Unit -vvv",
+    "test:unit": "forge test --match-path 'test/unit/**' -vvv",
     "test:unit:deep": "FOUNDRY_FUZZ_RUNS=5000 yarn test:unit"
   },
   "lint-staged": {


### PR DESCRIPTION
this is to avoid renaming of test contracts  due to migration to btt from having false CI negatives