### PR TITLE
feat: adding btt tests for bPool setters

### DIFF
--- a/test/unit/BPool/BPool.tree
+++ b/test/unit/BPool/BPool.tree
@@ -5,6 +5,32 @@ BPool::constructor
     ├── it sets swap fee to MIN_FEE
     └── it does NOT finalize the pool
 
+BPool::setSwapFee
+├── when reentrancy lock is set
+│   └── it should revert
+├── when caller is not controller
+│   └── it should revert
+├── when pool is finalized
+│   └── it should revert
+├── when swap fee is below MIN_FEE
+│   └── it should revert
+├── when swap fee is above MAX_FEE
+│   └── it should revert
+└── when preconditions are met
+    ├── it emits LOG_CALL event
+    └── it sets swap fee
+
+BPool::setController
+├── when reentrancy lock is set
+│   └── it should revert
+├── when caller is not controller
+│   └── it should revert
+├── when new controller is zero address
+│   └── it should revert
+└── when preconditions are met
+    ├── it emits LOG_CALL event
+    └── it sets new controller
+
 BPool::isFinalized
 ├── when pool is finalized
 │   └── it returns true


### PR DESCRIPTION
isn't pretty, but there's no "valid for all" scenario in the BPool miscelaneous test, so i'm ok with declaring the pre-conditions in each leaf of the tree, open to discuss